### PR TITLE
delete :) $ mai delete myteam

### DIFF
--- a/components/mai.rst
+++ b/components/mai.rst
@@ -18,11 +18,6 @@ Creating a new profile:
     $ SAML username: john.doe@example.org # Enter your SAML username
     # answer the questions
 
-Deleting a profile:
-
-.. code-block:: bash
-
-    $ mai delete myteam
     
 List profile(s):
 


### PR DESCRIPTION
I tried out this command and it did not work. So I deleted it from the documentation. Further you can not found it under mai -h.
