### PR TITLE
Add some configurationProperties

### DIFF
--- a/components/senza.rst
+++ b/components/senza.rst
@@ -195,12 +195,15 @@ This component supports the following configuration properties:
 ``ElasticLoadBalancer``
     Name of the ELB resource.
 ``TaupageConfig``
-    Taupage AMI config, see :ref:`taupage` for details.
+    Taupage AMI config, see :ref:`taupage` for details. 
+        ``runtime?``
+        ``source?``
+        ``ports?``
+        ``environments?``
 ``AutoScaling``
     Map of auto scaling properties, see below.
 
 ``AutoScaling`` properties are:
-
 ``Minimum``
     Minimum number of instances to spawn.
 ``Maximum``


### PR DESCRIPTION
- line 198 the link does not work. It shows on the current document zalando-stups/documentation/components/senza.rst
- line 197 - 202 missing some definitions of the production.yaml elements. I have listed the missing elements but a description is missing
