### PR TITLE
add informations for BlockDeviceMappings

### DIFF
--- a/components/senza.rst
+++ b/components/senza.rst
@@ -241,7 +241,7 @@ This component supports the following configuration properties:
     Taupage AMI config, see :ref:`taupage` for details.
     At least the properties ``runtime`` ("Docker") and ``source`` (Docker image) are required.
     Usually you will want to specify ``ports`` and ``environment`` too.
-``AssociatePublicIpAddress
+``AssociatePublicIpAddress``
     Whether to associate EC2 instances with a public IP address. This boolean value (true/false) is false by default.
 ``BlockDeviceMappings``
     Spcify additional EBS Devices you want to attach to the nodes. See for Option Map below.

--- a/components/senza.rst
+++ b/components/senza.rst
@@ -241,8 +241,10 @@ This component supports the following configuration properties:
     Taupage AMI config, see :ref:`taupage` for details.
     At least the properties ``runtime`` ("Docker") and ``source`` (Docker image) are required.
     Usually you will want to specify ``ports`` and ``environment`` too.
-``AssociatePublicIpAddress``
+``AssociatePublicIpAddress
     Whether to associate EC2 instances with a public IP address. This boolean value (true/false) is false by default.
+``BlockDeviceMappings``
+    Spcify additional EBS Devices you want to attach to the nodes. See for Option Map below.
 ``AutoScaling``
     Map of auto scaling properties, see below.
 
@@ -259,8 +261,18 @@ This component supports the following configuration properties:
 ``ScaleDownThreshold``
     On which value of the metric to scale down. For the "CPU" metric: a value of 40 would mean 40% CPU usage.
 
+``BlockDeviceMappings`` properties are:
 
+``DeviceName``
+    For example: /dev/xvdk
+``Ebs``
+    Map of EBS Options, see below.
+    
 
+``Ebs`` properties are:
+
+``VolumeSize``
+    How Much GB should this EBS have?
 Senza::WeightedDnsElasticLoadBalancer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
BlockDeviceMappings documentation was missing, but those informations got created through senza. I now added only the docs which i use, there are probably more options.
