### PR TITLE
Update .zappr.yaml

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -1,2 +1,2 @@
 X-Zalando-Type: "doc"
-# TODO: Add X-Zalando-Team
+X-Zalando-Team: "stups"

--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -1,15 +1,2 @@
-approvals:
-  # PR needs at least 2 approvals
-  minimum: 1
-  # approval = comment that matches this regex
-  pattern: "^(:\\+1:|👍)"
-  # note that `from` is by default empty,
-  # accepting any matching comment as approval
-  from:
-    # commenter must be either one of:
-    orgs:
-      # a public zalando org member
-      # (any org in here counts)
-      - zalando
-    # OR a collaborator of the repo
-    collaborators: true
+X-Zalando-Type: "doc"
+# TODO: Add X-Zalando-Team


### PR DESCRIPTION
For documentation repositories we don't need to have Zappr enabled, so I deleted the configuration. The team has still to be added.
