### PR TITLE
Add DesiredCapacity to documentation

### DIFF
--- a/components/senza.rst
+++ b/components/senza.rst
@@ -441,6 +441,8 @@ This component supports the following configuration properties:
     Minimum number of instances to spawn.
 ``Maximum``
     Maximum number of instances to spawn.
+``DesiredCapacity```
+    Desired number of instances to spawn.
 ``SuccessRequires``:
     During startup of the stack, define when your ASG is considered healthy by CloudFormation. Defaults to one healthy instance within 15 minutes. To change it to 4 healthy instances within 1 hour, 20 minutes and 30 seconds pass "4 within 1h20m30s" (you can omit hours/minutes/seconds as you please). Values that look like integers will be used as healthy instance count, e.g. "2" would be interpreted as 2 healthy instances within the default timeout of 15 minutes.
 ``MetricType``


### PR DESCRIPTION
I was looking for way to set desired number for an auto scaling group but couldn't find anything in the docs but after reading the code, found out it is possible. 
