### PR TITLE
Add documentation for supporting --shm-size in docker configuration

### DIFF
--- a/components/taupage.rst
+++ b/components/taupage.rst
@@ -317,6 +317,14 @@ read_only:
 The container will run with --read-only option.
 Mount the container's root filesystem as read only.
 
+shm_size:
+----------
+
+**(optional, default: 64M)**
+
+The container will run with --shm-size option.
+To set /dev/shm size.
+
 mount_var_log:
 --------------
 


### PR DESCRIPTION
Add documentation for supporting --shm-size in docker configuration based on https://github.com/zalando-stups/taupage/pull/437