### PR TITLE
Update piu+scp docs to account for instance connect changes

### DIFF
--- a/user-guide/ssh-access.rst
+++ b/user-guide/ssh-access.rst
@@ -71,6 +71,12 @@ Luckily OpenSSH's ``scp`` supports jump hosts with the ``ProxyCommand`` configur
 
     $ scp -o ProxyCommand="ssh -W %h:%p odd@odd-eu-west-1.myteam.example.org" mylocalfile.txt ubuntu@172.31.146.1:
 
+If you're using an old version of Taupage (AMI prior to 2020-02-20) you can omit the usernames to achieve the same:
+
+.. code-block:: bash
+
+    $ scp -o ProxyCommand="ssh -W %h:%p odd-eu-west-1.myteam.example.org" mylocalfile.txt 172.31.146.1:
+
 See also the `OpenSSH Cookbook on Proxies and Jump Hosts`_.
 
 

--- a/user-guide/ssh-access.rst
+++ b/user-guide/ssh-access.rst
@@ -69,7 +69,7 @@ Luckily OpenSSH's ``scp`` supports jump hosts with the ``ProxyCommand`` configur
 
 .. code-block:: bash
 
-    $ scp -o ProxyCommand="ssh -W %h:%p odd-eu-west-1.myteam.example.org" mylocalfile.txt 172.31.146.1:
+    $ scp -o ProxyCommand="ssh -W %h:%p odd@odd-eu-west-1.myteam.example.org" mylocalfile.txt ubuntu@172.31.146.1:
 
 See also the `OpenSSH Cookbook on Proxies and Jump Hosts`_.
 

--- a/user-guide/ssh-access.rst
+++ b/user-guide/ssh-access.rst
@@ -69,13 +69,13 @@ Luckily OpenSSH's ``scp`` supports jump hosts with the ``ProxyCommand`` configur
 
 .. code-block:: bash
 
-    $ scp -o ProxyCommand="ssh -W %h:%p odd@odd-eu-west-1.myteam.example.org" mylocalfile.txt ubuntu@172.31.146.1:
+    $ scp -o "ProxyJump odd@odd-eu-west-1.myteam.example.org" mylocalfile.txt ubuntu@172.31.146.1:
 
 If you're using an old version of Taupage (AMI prior to 2020-02-20) you can omit the usernames to achieve the same:
 
 .. code-block:: bash
 
-    $ scp -o ProxyCommand="ssh -W %h:%p odd-eu-west-1.myteam.example.org" mylocalfile.txt 172.31.146.1:
+    $ scp -o "ProxyJump odd-eu-west-1.myteam.example.org" mylocalfile.txt 172.31.146.1:
 
 See also the `OpenSSH Cookbook on Proxies and Jump Hosts`_.
 


### PR DESCRIPTION
When using instance connect the old docs for scp didn't work anymore. Specifying both usernames fixed the problem.